### PR TITLE
Fix fields getting wrong parent

### DIFF
--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -793,7 +793,7 @@ class ProtobufParser
                     )
                 );
 
-                $enum = new EnumDescriptor($name, $file, $message);
+                $enum = new EnumDescriptor($name, $file, $parent);
                 $this->_parseEnum($enum, $content);
                 // removing it from string
                 $messageContent = '' . trim(substr($messageContent, $offset['end']));


### PR DESCRIPTION
Hi!

There is a problem with nested messages when any sibling element following message declaration get this message as a parent. It can be reproduced in this case:

```
message Foo
{
    message Bar
    {
    }
    optional Bar bar = 1;
}
```

which results in

```
Foo->_fields = array()
Foo->_nested[Bar]->fields = array(bar)
```

instead of expected

```
Foo->_fields = array(bar)
Foo->_nested[Bar]->fields = array()
```

Here comes the patch ;-)
