### PR TITLE
Allow "option" fields in proto files

### DIFF
--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -900,6 +900,11 @@ class ProtobufParser
 
                 $file->addDependency($pbp->parse($includedFilename));
 
+            } else if (strtolower($next) == 'option') {
+
+                // We don't support option parameters just yet, skip for now.
+                $messageContent = preg_replace('/^.+\n/', '', $messageContent);
+                
             } else if (strtolower($next) == 'package') {
 
                 $match = preg_match(


### PR DESCRIPTION
As PR [#22](https://github.com/allegro/php-protobuf/pull/22) has proven difficult to implement, this PR simply makes the compiler allow (and ignore) option parameters in `.proto` files.

Without this, `.proto` files with any option field (even official ones) fail to compile.
