### PR TITLE
Parsing proto files with repeated file imports bugfix

### DIFF
--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -896,6 +896,8 @@ class ProtobufParser
                 if (!isset(self::$_parsers[$parserKey])) {
                     $pbp = new ProtobufParser($this->_useNativeNamespaces);
                     self::$_parsers[$parserKey] = $pbp;
+                } else {
+                    $pbp = self::$_parsers[$parserKey];
                 }
 
                 $file->addDependency($pbp->parse($includedFilename));


### PR DESCRIPTION
Fixing bug that would result in no output when a .proto file contained an import cycle which resulted in including the same file multiple times over the include chain