### PR TITLE
Allow for handling objects as they are read by the parser

### DIFF
--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -916,7 +916,7 @@ class ProtobufParser
             ->appendParam('param', 'array $callback in the following format: array($anObject, \'someMethod\')')
             ->appendParam('return', 'null');
         $buffer->append($comment)
-            ->append('public function registerObjectReadyCallback($callback)')
+            ->append('public static function registerObjectReadyCallback($callback)')
             ->append('{')
             ->increaseIdentation()
             ->append('self::$objectReadyCallbacks[] = $callback;')

--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -28,7 +28,7 @@ class ProtobufParser
     private $_hasSplTypes = false;
     private $_useNativeNamespaces = false;
 
-    private $_filenamePrefix = 'pb_proto_';
+    private $_filenamePrefix = 'pb_';
     private $_savePsrOutput = false;
 
     private $_comment;
@@ -755,6 +755,9 @@ class ProtobufParser
      */
     private function _createClassConstructor($fields, CodeStringBuffer $buffer)
     {
+        $buffer->append('private static $objectReadyCallbacks = array();');
+        $buffer->newline();
+
         $buffer->append('/* Field index constants */');
 
         foreach ($fields as $field) {
@@ -877,6 +880,47 @@ class ProtobufParser
         }
 
         $buffer->decreaseIdentation()
+            ->append('}')
+            ->newline();
+
+        $comment = new CommentStringBuffer(self::TAB, self::EOL);
+        $comment->append(
+            'Called by the parser once a member object has been fully read in'
+        )
+            ->newline()
+            ->appendParam('return', 'null');
+        $buffer->append($comment)
+            ->append('public function objectReady()')
+            ->append('{')
+            ->increaseIdentation()
+            ->append('foreach (self::$objectReadyCallbacks as $callback) {')
+            ->increaseIdentation()
+            ->append('$result = $callback($this);')
+            ->append('if ($result === false) {')
+            ->increaseIdentation()
+            ->append('return false;')
+            ->decreaseIdentation()
+            ->append('}')
+            ->decreaseIdentation()
+            ->append('}')
+            ->append('return true;')
+            ->decreaseIdentation()
+            ->append('}')
+            ->newline();
+
+        $comment = new CommentStringBuffer(self::TAB, self::EOL);
+        $comment->append(
+            'Add a callback that will be run when the object is ready'
+        )
+            ->newline()
+            ->appendParam('param', 'array $callback in the following format: array($anObject, \'someMethod\')')
+            ->appendParam('return', 'null');
+        $buffer->append($comment)
+            ->append('public function registerObjectReadyCallback($callback)')
+            ->append('{')
+            ->increaseIdentation()
+            ->append('self::$objectReadyCallbacks[] = $callback;')
+            ->decreaseIdentation()
             ->append('}')
             ->newline();
     }


### PR DESCRIPTION
Hi,
In my project, we are dealing with very large amounts of data coming from the client.  This has caused us memory issues in PHP.  So we are converting to using php-protobuf, but we need to use it in a "streaming" fashion, rather than having the entire contents of the .pb file read into one monster PHP object.
This commit implements this streaming capability.  It changes the code generator to add an objectReady function to each object, and this function calls any registered handler callbacks.  I've changed the parser code to call this function when an object has been fully instantiated and populated.

Below is some example code of how this can be used.  For us, we want to process the "event" objects, and then destroy them (these occupy much of the memory in our use case).

```php
<?php
require_once 'pb_sync.php';

function out($str) {
    echo $str . "\n";
}

class SsCli {
    private $syncData;
    private $currentDevice;
    private $count = 0;

    private function getCurrentDevice() {
        if (is_null($this->currentDevice)) {
            $this->currentDevice = $this->syncData->getDevicesAt($this->syncData->getDevicesCount() - 1);
        }
        return $this->currentDevice;
    }

    public function handlerDevice($device) {
        //we have finished processing this device, so forget it so getCurrentDevice gets the new one
        $this->currentDevice = null;
    }

    public function handlerEvent($event) {
        $device = $this->getCurrentDevice();
        //this is our "processing" step, which of course, would be doing more than just outputting a timestamp
        out("device {$device->getDeviceIdHigh()} has an event timestamp: " . $event->getOrderTimestamp());

//how to stop processing
// if a callback returns false, it will be sensed in protobuf.c and abort parsing
//        if ($event->getOrderTimestamp() == 946684801) {
//            return false;
//        }
 
       //this clears out the event, so our memory stays clean 
        $this->currentDevice->clearEvents();
    }

    public function process() {
        $tempFilename = dirname(__FILE__).'/syncData.pb';

        $this->syncData = new SyncData();
        Event::registerObjectReadyCallback(array($this, 'handlerEvent'));
        Device::registerObjectReadyCallback(array($this, 'handlerDevice'));

        try {
            $this->syncData->parseFromString(file_get_contents($tempFilename));
        } catch (Exception $e) {
            out($e->getMessage());
        }
    }
}

$ssCli = new SsCli();
$ssCli->process();
```
