### PR TITLE
Fixed segmentation fault when using the extension in Ubuntu 14.04

### DIFF
--- a/writer.c
+++ b/writer.c
@@ -196,7 +196,7 @@ static inline void writer_write_varint(writer_t *writer, int64_t value)
 	uint8_t byte;
 
 	if (writer_ensure_space(writer, WRITER_VARINT_SPACE) != 0)
-		return -1;
+		return;
 
 	if (value == 0) {
 		writer->data[writer->pos++] = 0;

--- a/writer.c
+++ b/writer.c
@@ -195,6 +195,9 @@ static inline void writer_write_varint(writer_t *writer, int64_t value)
 	int i;
 	uint8_t byte;
 
+	if (writer_ensure_space(writer, WRITER_VARINT_SPACE) != 0)
+		return -1;
+
 	if (value == 0) {
 		writer->data[writer->pos++] = 0;
 	} else if (value < 0) {


### PR DESCRIPTION
Not sure why it makes a difference, but when I use this extension in Ubuntu 10.04 and 12.04 it works fine, but on 14.04 I get segmentation faults during calls to serializeToString.
This change seems to fix it.
