### PR TITLE
Improve the .proto parser alility

### DIFF
--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -1081,7 +1081,7 @@ class ProtobufParser
         // parse the value
         $match = preg_match(
             '/(optional|required|repeated)[\s]+([^;^=^\s^]+)' .
-            '[\s]+([^;^=^\s]+)[\s]+=[\s]+([\d]+);/',
+            '[\s]+([^;^=^\s]+)[\s]*=[\s]*([\d]+)[\s]*;/',
             $content,
             $matches
         );


### PR DESCRIPTION
befor just can define:
optional/required/repeated type typeName = value;
after:
optional/required/repeated type typeName = value ;
optional/required/repeated type typeName=value;