### PR TITLE
Edit the php protobuf compiler for compiling and referencing dependencies in their own directories

### DIFF
--- a/ProtobufCompiler/FileDescriptor.php
+++ b/ProtobufCompiler/FileDescriptor.php
@@ -17,6 +17,9 @@ class FileDescriptor
     private $_name;
 
     /** @var string */
+    private $_compiledFilename;
+
+    /** @var string */
     private $_package;
 
     /**
@@ -137,5 +140,25 @@ class FileDescriptor
     public function setPackage($package)
     {
         $this->_package = $package;
+    }
+
+    /**
+     * Sets the relative path of the compiled file. Does not support setting
+     * all the files compiled for the psr-4 directory structure.
+     *
+     * @param string $compiled_filename
+     */
+    public function setCompiledFilename($compiledFilename) {
+        $this->_compiledFilename = $compiledFilename;
+    }
+
+    /**
+     * Gets the relative path of the compiled file. Does not support listing
+     * all the files compiled for the psr-4 directory structure.
+     *
+     * @param string $compiled_filename
+     */
+    public function getCompiledFilename() {
+        return $this->_compiledFilename;
     }
 }

--- a/protoc-php.php
+++ b/protoc-php.php
@@ -16,11 +16,12 @@ if (!debug_backtrace()) {
     $filenamePrefix = false;
     $outputPsr = false;
     $targetDir = false;
+    $shouldCompileInPlace = false;
 
     $iterator = new \RegexIterator(new \ArrayIterator($argv), '/^-/');
 
     $shortOpts = "np:t:";
-    $longOpts = array("use-namespaces", "filename-prefix:", "psr");
+    $longOpts = array("use-namespaces", "filename-prefix:", "psr", "compile-in-place");
 
     $options = getOpt($shortOpts, $longOpts);
 
@@ -42,6 +43,9 @@ if (!debug_backtrace()) {
                 break;
             case 't':
                 $targetDir = rtrim($value, '/') . '/';
+                break;
+            case 'compile-in-place':
+                $shouldCompileInPlace = true;
                 break;
             default :
                 $optionError = true;
@@ -72,13 +76,14 @@ if (!debug_backtrace()) {
         printf('  -p, --filename-prefix [PREFIX]    Specify a prefix for generated file names' . PHP_EOL);
         printf('  -t [path]                         Target directory for output' . PHP_EOL);
         printf('  --psr                             Output class files in a psr-4 directory structure' . PHP_EOL);
+        printf('  --compile-in-place                Generated files will be outputted in the same directory as their source files' . PHP_EOL);
         exit(1);
     }
 
     // Reindex argv
     $GLOBALS['argv'] = array_values($GLOBALS['argv']);
 
-    $parser = new ProtobufParser($useNamespaces);
+    $parser = new ProtobufParser($useNamespaces, $shouldCompileInPlace);
 
     if ($filenamePrefix !== false) {
         $parser->setFilenamePrefix($filenamePrefix);


### PR DESCRIPTION
#### Edit the php protobuf compiler to compile dependencies in their own directories and have require_once statements point to those compiled files

Use case: when I compile a proto file, the file itself and any imported proto files should all be compiled in the folder they're currently in, instead of the current working directory of the script.

Changes made:
* added a new input option: `--compile-in-place`, that takes the directory of the proto source file and uses that as the path for the generated/compiled file
* a proto file is associated with its compiled filename
* when an `import "some_file.proto"` statement is encountered by the compiler, it will use the compiled file path in the generated php `require_once "..."` statement

Testing done:
* made folder1/ with proto files
* made folder2/ with proto files that imported the files in folder 1
* in the base folder that contained both folder1 and folder2, ran:
  * `php $PHP_COMPILE_SCRIPT --compile-in-place <path to proto file>`
* Verified the compiled files for each file were in their respective folders
* Verified that the compiled php file in folder2/ had `require_once` statements that referred to the compiled files in folder1/