### PR TITLE
Fix compiler output file path issue by adding _path_join() to do the path join

### DIFF
--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -1381,14 +1381,10 @@ class ProtobufParser
 
     private static function _path_join()
     {
-        $args = func_get_args();
-        $paths = array();
-        foreach ($args as $arg) {
-            $paths = array_merge($paths, (array)$arg);
-        }
-
-        $paths = array_map(create_function('$p', 'return trim($p, "/");'), $paths);
-        $paths = array_filter($paths);
-        return join('/', $paths);
+        $paths = func_get_args();
+        $mapper = function ($path) {
+            return trim($path, DIRECTORY_SEPARATOR);
+        };
+        return join(DIRECTORY_SEPARATOR, array_map($mapper, $paths));
     }
 }

--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -308,7 +308,7 @@ class ProtobufParser
         }
 
         if (!$this->getSavePsrOutput()) {
-            file_put_contents($this->getTargetDir() . $outputFile, '<?php' . PHP_EOL . $buffer);
+            file_put_contents(self::_path_join($this->getTargetDir(), $outputFile), '<?php' . PHP_EOL . $buffer);
         }
     }
 
@@ -1377,5 +1377,18 @@ class ProtobufParser
         $string = preg_replace('/\/\/.*/', '', $string);
         // now replace empty lines and whitespaces in front
         $string = preg_replace('/\\r?\\n\s*/', PHP_EOL, $string);
+    }
+
+    private static function _path_join()
+    {
+        $args = func_get_args();
+        $paths = array();
+        foreach ($args as $arg) {
+            $paths = array_merge($paths, (array)$arg);
+        }
+
+        $paths = array_map(create_function('$p', 'return trim($p, "/");'), $paths);
+        $paths = array_filter($paths);
+        return join('/', $paths);
     }
 }


### PR DESCRIPTION
[Problem]
`php protoc-php.php xxx.proto` generates `.pb_proto_xxx.php` rather than `pb_proto_xxx.php`

[Solution]
Add static method `_path_join()` to Parser module

[Test]
```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.4 LTS
Release:        14.04
Codename:       trusty

$ php -v
PHP 5.5.9-1ubuntu4.14 (cli) (built: Oct 28 2015 01:34:46)
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.5, Copyright (c) 1999-2015, by Zend Technologies
```