### PR TITLE
Fixes a problem with subfields that protobuf serialize to 0 bytes.

### DIFF
--- a/protobuf.c
+++ b/protobuf.c
@@ -900,8 +900,8 @@ static int pb_serialize_field_value(zval *this, writer_t *writer, uint32_t field
 		if (Z_TYPE(ret) != IS_STRING)
 			return -1;
 
-		if (Z_STRLEN(ret) > 0)
-			writer_write_message(writer, field_number, Z_STRVAL(ret), Z_STRLEN(ret));
+		// previously this ignored subfields of protobuf size 0. But repeated/optional means that's perfectly valid.
+		writer_write_message(writer, field_number, Z_STRVAL(ret), Z_STRLEN(ret));
 
 		zval_dtor(&ret);
 	} else if (Z_TYPE_PP(type) == IS_LONG) {

--- a/tests/zero_encode_field.phpt
+++ b/tests/zero_encode_field.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Protocol Buffers should output subfields even if they encode to 0 bytes.
+--SKIPIF--
+<?php require 'skipif.inc' ?>
+--FILE--
+<?php
+require 'zerofield.inc';
+
+$obj = new ObjectArray();
+$s1 = new StringArray(); $s1->setData("one"); $obj->appendObject($s1);
+$s2 = new StringArray(); $s2->setData("two"); $obj->appendObject($s2);
+$s3 = new StringArray(); $obj->appendObject($s3);
+
+var_dump($obj->getObjectCount());
+
+$ser = $obj->serializeToString();
+
+$test = new ObjectArray();
+$test->parseFromString($ser);
+
+var_dump($test->getObjectCount());
+
+?>
+--EXPECT--
+int(3)
+int(3)

--- a/tests/zerofield.inc
+++ b/tests/zerofield.inc
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Auto generated from example.proto at 2016-04-21 14:47:57
+ */
+
+/**
+ * StringArray message
+ */
+class StringArray extends \ProtobufMessage
+{
+    /* Field index constants */
+    const DATA = 1;
+
+    /* @var array Field descriptors */
+    protected static $fields = array(
+        self::DATA => array(
+            'name' => 'data',
+            'required' => false,
+            'type' => 7,
+        ),
+    );
+
+    /**
+     * Constructs new message container and clears its internal state
+     *
+     * @return null
+     */
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    /**
+     * Clears message values and sets default ones
+     *
+     * @return null
+     */
+    public function reset()
+    {
+        $this->values[self::DATA] = null;
+    }
+
+    /**
+     * Returns field descriptors
+     *
+     * @return array
+     */
+    public function fields()
+    {
+        return self::$fields;
+    }
+
+    /**
+     * Sets value of 'data' property
+     *
+     * @param string $value Property value
+     *
+     * @return null
+     */
+    public function setData($value)
+    {
+        return $this->set(self::DATA, $value);
+    }
+
+    /**
+     * Returns value of 'data' property
+     *
+     * @return string
+     */
+    public function getData()
+    {
+        return $this->get(self::DATA);
+    }
+}
+
+/**
+ * ObjectArray message
+ */
+class ObjectArray extends \ProtobufMessage
+{
+    /* Field index constants */
+    const OBJECT = 1;
+
+    /* @var array Field descriptors */
+    protected static $fields = array(
+        self::OBJECT => array(
+            'name' => 'object',
+            'repeated' => true,
+            'type' => 'StringArray'
+        ),
+    );
+
+    /**
+     * Constructs new message container and clears its internal state
+     *
+     * @return null
+     */
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    /**
+     * Clears message values and sets default ones
+     *
+     * @return null
+     */
+    public function reset()
+    {
+        $this->values[self::OBJECT] = array();
+    }
+
+    /**
+     * Returns field descriptors
+     *
+     * @return array
+     */
+    public function fields()
+    {
+        return self::$fields;
+    }
+
+    /**
+     * Appends value to 'object' list
+     *
+     * @param StringArray $value Value to append
+     *
+     * @return null
+     */
+    public function appendObject(StringArray $value)
+    {
+        return $this->append(self::OBJECT, $value);
+    }
+
+    /**
+     * Clears 'object' list
+     *
+     * @return null
+     */
+    public function clearObject()
+    {
+        return $this->clear(self::OBJECT);
+    }
+
+    /**
+     * Returns 'object' list
+     *
+     * @return StringArray[]
+     */
+    public function getObject()
+    {
+        return $this->get(self::OBJECT);
+    }
+
+    /**
+     * Returns 'object' iterator
+     *
+     * @return ArrayIterator
+     */
+    public function getObjectIterator()
+    {
+        return new \ArrayIterator($this->get(self::OBJECT));
+    }
+
+    /**
+     * Returns element from 'object' list at given offset
+     *
+     * @param int $offset Position in list
+     *
+     * @return StringArray
+     */
+    public function getObjectAt($offset)
+    {
+        return $this->get(self::OBJECT, $offset);
+    }
+
+    /**
+     * Returns count of 'object' list
+     *
+     * @return int
+     */
+    public function getObjectCount()
+    {
+        return $this->count(self::OBJECT);
+    }
+}

--- a/tests/zerofield.proto
+++ b/tests/zerofield.proto
@@ -1,0 +1,7 @@
+message StringArray {
+ optional string data = 1;
+}
+
+message ObjectArray {
+ repeated StringArray object = 1;
+}


### PR DESCRIPTION
It's quite normal for repeated/optional fields to mean a message's protobuf serialization is 0 bytes. Previously, serialize checked subfields for 0 byte serialization and ignored them - this caused "empty" objects to be dropped (rather than serialized as (field_number<<3) | length_delimited 0x00). Took the length > 0 test out, added a test case that includes such an empty sub-object and make sure it parses back in correctly.