### PR TITLE
bug, filter syntax declare in proto

### DIFF
--- a/ProtobufCompiler/ProtobufParser.php
+++ b/ProtobufCompiler/ProtobufParser.php
@@ -1374,6 +1374,10 @@ class ProtobufParser
      */
     private function _stripComments(&$string)
     {
+	/**
+         * rm not supported syntax declare.songtzu
+         */
+	$string = preg_replace('/syntax.*;/','',$string);
         $string = preg_replace('/\/\/.*/', '', $string);
         // now replace empty lines and whitespaces in front
         $string = preg_replace('/\\r?\\n\s*/', PHP_EOL, $string);


### PR DESCRIPTION
maybe, we should filter the syntax declare in proto file.
in fact, I suggest check the syntax declare to find out php-proto support this syntax or not.