### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ There might be situations you need to investigate what actual content of the giv
 
             $packed = $foo->serializeToString();
 
-            $foo->clear();
+            $foo->reset();
 
             try {
                 $foo->parseFromString($packed);


### PR DESCRIPTION
The ProtobufMessage::clear($position) intends to clear one field of the class, which in this case triggers the following warning:
PHP Warning:  ProtobufMessage::clear() expects exactly 1 parameter, 0 given in test_pb_foo.php on line 13

Here, to clear the entire class Foo object, instead of ProtobufMessage::clear($position), the ProtobufMessage::reset() should be used.  Attach reset function in protocol generated class Foo:
    public function reset()
    {
        $this->values[self::BAR] = null;
        $this->values[self::BAZ] = null;
        $this->values[self::SPAM] = array();
    }

